### PR TITLE
feat: add an overrideable output to the EmbedPoolStack model

### DIFF
--- a/eight_mile/pytorch/layers.py
+++ b/eight_mile/pytorch/layers.py
@@ -1128,13 +1128,21 @@ class EmbedPoolStackModel(nn.Module):
 
     """
 
-    def __init__(self, nc: int, embeddings: nn.Module, pool_model: nn.Module, stack_model: Optional[nn.Module] = None):
+    def __init__(
+        self,
+        nc: int,
+        embeddings: nn.Module,
+        pool_model: nn.Module,
+        stack_model: Optional[nn.Module] = None,
+        output_model: Optional[nn.Module] = None,
+    ):
         super().__init__()
         self.embed_model = embeddings
         self.pool_model = pool_model
         output_dim = self.pool_model.output_dim if stack_model is None else stack_model.output_dim
         self.output_layer = Dense(output_dim, nc, activation="log_softmax")
         self.stack_model = stack_model if stack_model else nn.Identity()
+        self.output_layer = Dense(output_dim, nc, activation="log_softmax") if output_model is None else output_model
 
     def forward(self, inputs: Dict[str, torch.Tensor]):
         lengths = inputs["lengths"]

--- a/eight_mile/tf/layers.py
+++ b/eight_mile/tf/layers.py
@@ -2279,7 +2279,7 @@ class LangSequenceModel(tf.keras.Model):
 
 
 class EmbedPoolStackModel(tf.keras.Model):
-    def __init__(self, nc, embeddings, pool_model, stack_model=None):
+    def __init__(self, nc, embeddings, pool_model, stack_model=None, output_model=None):
         super().__init__()
         if isinstance(embeddings, dict):
             self.embed_model = EmbeddingsStack(embeddings)
@@ -2290,9 +2290,9 @@ class EmbedPoolStackModel(tf.keras.Model):
         self.pool_requires_length = False
         if hasattr(pool_model, "requires_length"):
             self.pool_requires_length = pool_model.requires_length
-        self.output_layer = tf.keras.layers.Dense(nc)
         self.pool_model = pool_model
         self.stack_model = stack_model
+        self.output_layer = tf.keras.layers.Dense(nc) if output_model is None else output_model
 
     def call(self, inputs):
         lengths = inputs.get("lengths")


### PR DESCRIPTION
This PR adds the ability to override the output of the EmbedPoolStack model in pytorch and TF